### PR TITLE
fixes empty tree performance issue

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -223,7 +223,7 @@ genRenderTree depth e t =
         Eq x y    -> RenderChildren [gTree x, gTree y]
         And x y   -> RenderChildren [gTree x, gTree y]
         Or x y    -> RenderChildren [gTree x, gTree y]
-        EmptyTree -> RenderChildren [gTree EmptyTree, gTree EmptyTree] --- not valid, just for debuging
+        EmptyTree -> RenderChildren []
 
   in
   { render = True


### PR DESCRIPTION
The existing rule for EmptyTree was to produce two more EmptyTree nodes, producing an infinite tree, which in turn caused performance issues and weird rendering.

This PR changes the rule to generate no children, preventing infinite trees.