### PR TITLE
Type error

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,7 +8,8 @@
         "direct": {
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
-            "elm/html": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm-community/list-extra": "8.1.0"
         },
         "indirect": {
             "elm/json": "1.1.3",

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -178,7 +178,8 @@ genRenderTree depth e t =
   let
     dnew = depth - 1
     gTree = genRenderTree dnew e
-    c =
+    checkStatus = Render.typecheck3 e t
+    children =
       case t of
         CTerm _   -> []
         VTerm x   ->
@@ -194,8 +195,15 @@ genRenderTree depth e t =
         EmptyTree -> []
 
     n = 
-      { render = (depth > 0)
-      , term = t}
+      -- always render render nodes that don't pass typecheck
+      case checkStatus of
+        Checks _ -> 
+          { render = (depth > 0)
+          , term = t}
+        
+        _ ->
+          { render = True
+          , term = t}
 
   in
-    Node n c
+    Node n children

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -175,7 +175,7 @@ genRenderTree depth e t =
         Eq x y    -> [gTree x, gTree y]
         And x y   -> [gTree x, gTree y]
         Or x y    -> [gTree x, gTree y]
-        EmptyTree -> [gTree EmptyTree, gTree EmptyTree] --- not valid, just for debuging
+        EmptyTree -> [] --- not valid, just for debuging
 
     n = 
       { render = (depth >= 0)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -323,11 +323,17 @@ type alias RenderNode =
   { render: Bool
   , term: Term }
 
+{-
+RenderTreeInfo contains all of the information necessary to generate a
+RenderTree
+-}
 type alias RenderTreeInfo =
   { id: Int
   , var: Var
   , depth: Int }
 
+
+-- creates a render tree from a rtInfo and an environment
 genRenderTree2 : RenderTreeInfo -> Env -> RenderTree
 genRenderTree2 rtInfo env =
   genRenderTree rtInfo.depth env rtInfo.var.term

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -93,21 +93,6 @@ filterUpdate cond upd xs =
 Generates a list of render infos.  This function exists mostly so that render
 infos can recieve ids.
 -}
-{-genRenderInfosRec : Int -> Int -> List Var -> List RenderTreeInfo
-genRenderInfosRec i depth vars =
-  let
-    genNext = genRenderInfosRec (i + 1) depth
-  in
-    case vars of
-      []      -> []
-      v :: vs ->
-        [ { id = i
-          , var = v
-          , depth = depth
-          }
-        ] ++ genNext vs -}
-
--- curry starting index into fn
 genRenderInfos : Int -> List Var -> List RenderTreeInfo
 genRenderInfos depth vars =
   List.indexedMap 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -140,7 +140,7 @@ renderTerm e t =
     spanClass =
       case Render.typecheck3 e t of
         Checks _    -> "type-checks"
-        Fails _ _ _ -> "type-fails"
+        Fails _ _ _ _ -> "type-fails"
         Partial _   -> "type-partial"
         Invalid     -> "type-fails"
   in

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -175,12 +175,12 @@ renderTerm : Env -> Term -> Html Msg
 renderTerm e t =
   let
     spanClass =
-      case Render.typecheck3 e t of
+      case Render.typecheck e t of
         Checks _    -> "type-checks"
         Fails _ _ _ _ -> "type-fails"
         Partial _   -> "type-partial"
         Invalid     -> "type-fails"
-    checkResult = Render.typecheck3 e t
+    checkResult = Render.typecheck e t
   in
     div [ class "text-div" ]
     [ renderTermInline checkResult t 
@@ -337,7 +337,7 @@ genRenderTree depth e t =
   let
     dnew = depth - 1
     gTree = genRenderTree dnew e
-    checkStatus = Render.typecheck3 e t
+    checkStatus = Render.typecheck e t
     children =
       case t of
         CTerm _   -> []

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -180,11 +180,11 @@ renderSubtermsRec i ts c =
       [] -> [ text "" ]
       [t] ->
         case isFail of
-          True  -> [ span [class "error-subterm"] [text (Render.termToString t)] ]
+          True  -> [ span [class "error-subterm"] [text (Render.termToString t), renderErrorDiv c] ]
           False -> [ text (Render.termToString t) ]
       t :: ts2 ->
         case isFail of
-          True -> [ span [class "error-subterm"] [text (Render.termToString t)] ] ++
+          True -> [ span [class "error-subterm"] [text (Render.termToString t), renderErrorDiv c] ]  ++
             renderNext ts2 c
           False -> [ text (Render.termToString t) ] ++
             renderNext ts2 c
@@ -239,6 +239,19 @@ renderTermInline result t =
             text "rendering error"
       False ->
         text (Render.termToString t)
+
+
+renderErrorDiv : CheckResult -> Html Msg
+renderErrorDiv c =
+  case c of
+    Fails _ exp got out ->
+      let
+        expStr = Render.typeToString exp
+        gotStr = Render.typeToString got
+      in
+        div [class "error-details"] [ text ("Expected: " ++ expStr), br [] [], text ("Got: " ++ gotStr) ]
+    
+    _ -> div [class "error-details"] []
 
 
 {-

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -48,7 +48,6 @@ init _ =
 --testVars = [{ name = "a", term = CTerm (CInt 5)}]
 --testTerm = And (Eq (Times (Plus (CTerm (CInt 5)) (CTerm (CInt 1))) (CTerm (CInt 7))) (Times (CTerm (CInt 21)) (VTerm "a"))) (CTerm (CBool True))
 failTerm = Or (Eq (CTerm (CInt 1)) (CTerm (CBool True))) (CTerm (CBool False))
---testDepth = 3
 
 -- UPDATE
 
@@ -131,7 +130,7 @@ renderTerm : Env -> Term -> Html Msg
 renderTerm e t =
   div [ class "text-div" ]
   [ text (Render.termToString t ++ " : ")
-  , span [ class "type-span" ] [ text (Render.typeToString (Render.typecheck3 e t)) ]
+  , span [ class "type-span" ] [ text (Render.checkResultToString (Render.typecheck3 e t)) ]
   ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -194,7 +194,7 @@ genRenderTree depth e t =
         EmptyTree -> []
 
     n = 
-      { render = (depth >= 0)
+      { render = (depth > 0)
       , term = t}
 
   in

--- a/src/Render.elm
+++ b/src/Render.elm
@@ -157,7 +157,7 @@ checkResultToString r =
       typeToString t
 
     Fails argNum exp got out ->
-      "At argument " ++ String.fromInt argNum ++ " Expected: " ++ typeToString exp ++ ", Got: " ++ typeToString got
+      "Fails " ++ typeToString out
     
     Partial t ->
       "Partial " ++ typeToString t
@@ -250,7 +250,7 @@ typecheck3 env t =
         Minus _ _ -> [TInt, TInt, TInt]
         Times _ _ -> [TInt, TInt, TInt]
         Eq _ _    -> [TInt, TInt, TBool]
-        And _ _   -> [TBool, TBool, TInt]
+        And _ _   -> [TBool, TBool, TBool]
         Or _ _    -> [TBool, TBool, TBool]
         EmptyTree -> []
     

--- a/src/Render.elm
+++ b/src/Render.elm
@@ -150,8 +150,6 @@ typecheck2 env exp t =
       EmptyTree -> Node (None) []-}
 
 
-type CheckResult = Checks VType | Fails VType VType VType | Partial VType | Invalid
-
 checkResultToString : CheckResult -> String
 checkResultToString r =
   case r of
@@ -220,7 +218,10 @@ checkSig sig args =
                       _        -> checkSig rsig rargs
                   False -> Fails s t final
               
-              Invalid -> Invalid
+              Invalid ->
+                case checkSig rsig rargs of
+                  Checks t2 -> Partial t2
+                  _         -> checkSig rsig rargs
 
 
 

--- a/src/Render.elm
+++ b/src/Render.elm
@@ -137,7 +137,8 @@ checkSig sig args =
         else
           case (failIndex, failExp, failGot) of
             (Just i, Just exp, Just got) ->
-              Fails i exp got r
+              -- arbitrary decision to 1-index args, discuss?
+              Fails (i + 1) exp got r
             _ ->
               Invalid
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -19,4 +19,15 @@ type alias Var =
 
 type alias Env = (String -> Maybe Term)
 
-type CheckResult = Checks VType | Fails VType VType VType | Partial VType | Invalid
+{-
+CheckResult represents the outcome of typechecking a term
+
+Checks type : The term successfully typechecks to `type`
+Fails argNum expected got output : The terms fails typechecking, where
+  `argNum` was of type `got` instead of `expected`.  The term would have
+  output type `output`, had typechecking succeeded.
+Partial type : At the top level, the term typehcecking was successful with 
+  `type`, but an error occured somewhere in the derivation tree
+Invalid : Typechecking failed with no useful diagnostic info
+-}
+type CheckResult = Checks VType | Fails Int VType VType VType | Partial VType | Invalid

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -18,3 +18,5 @@ type alias Var =
   , term: Term }
 
 type alias Env = (String -> Maybe Term)
+
+type CheckResult = Checks VType | Fails VType VType VType | Partial VType | Invalid

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,5 +1,7 @@
 module Types exposing (..)
 
+type Tree a = Node a (List (Tree a))
+
 type Token = TokPlus | TokMinus | TokTimes | TokAssign | TokEq | TokAnd | TokOr | TokLParen | TokRParen | TokVar String | TokConstInt Int | TokConstBool Bool | TokInvalid | TokEnd
 
 type Const = CBool Bool | CInt Int

--- a/src/style.css
+++ b/src/style.css
@@ -84,7 +84,7 @@ body {
 
 .error-details {
     position: absolute;
-    bottom: 50px; right: 200px;
+    bottom: 50px;
     background-color: #FF6754;
     display: none;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -24,8 +24,16 @@ body {
     padding-top: 5px;
 }
 
-.type-span {
+.type-checks {
     background-color: #BEE0EE;
+}
+
+.type-fails {
+    background-color: #FF6754;
+}
+
+.type-partial {
+    background-color: #FFE554;
 }
 
 .summary {

--- a/src/style.css
+++ b/src/style.css
@@ -36,6 +36,10 @@ body {
     background-color: #FFE554;
 }
 
+.error-subterm {
+    background-color: #FF6754;
+}
+
 .summary {
     text-align: center;
     font-size: 12pt;

--- a/src/style.css
+++ b/src/style.css
@@ -37,7 +37,21 @@ body {
 }
 
 .error-subterm {
+    /* relative positioning is used here because an eror-details div needs to
+    use absolute positioning based on this element */
+    position: relative;
     background-color: #FF6754;
+}
+
+.error-subterm:hover .error-details {
+    display: block;
+}
+
+.error-details {
+    position: absolute;
+    bottom: 50px; right: 200px;
+    background-color: #FF6754;
+    display: none;
 }
 
 .summary {


### PR DESCRIPTION
The long awaited PR is ready!  Changes:

- typechecking now returns a `CheckResult`, which gives more information about how typechecking went
- as a result, typecheck now has an understanding of a 'partial' type check, where an error occurred somewhere in derivation, but not at this step
- this new understanding is put to use in producing more accurate visual representations of errors

A lot of changes to existing code were made in the process, so if I've made any questionable changes please let me know in review and we can fix it!