### PR TITLE
Closures and Type Signatures Implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 elm-stuff
+main.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 elm-stuff
+node_modules
 main.js
+bundle.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 elm-stuff
 node_modules
 main.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: elm
+
+script:
+  - elm-test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # Arboretum
-HaskellAssembyElmJavascript
+
+Arboretum is a project to explore the potential of displaying expressions and
+their types as visual trees in a browsers.  In the course of this project, we
+have begun building a new functional language, TreeScript (working name).
+
+# Technologies
+
+All of the language type checking and evaluation, as well as the rendering, is
+performed in Elm.  Lexing and Parsing is handled by Chevrotain, a parsing
+library written in Javascript.
+
+# Building
+
+After cloning the git repo, make sure you download
+[Chevrotain](https://github.com/SAP/chevrotain), our parsing library:
+
+```bash
+npm install chevrotain
+```
+
+Also make sure you download browserify, which we use to bundle all of the
+projects dependencies.
+
+```bash
+npm install -g browserify
+```
+
+To build the webpage, two javascript files need to be built: main.js
+containing the compiled Elm code, and bundle.js containing the parser and its
+dependencies.  The bash script `makearb.sh` automates the process, so run it
+now, and after any changes to Elm or JavaScript code to propagate the changes
+into the webpage.

--- a/elm.json
+++ b/elm.json
@@ -9,10 +9,10 @@
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
             "elm-community/list-extra": "8.1.0"
         },
         "indirect": {
-            "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"

--- a/index.html
+++ b/index.html
@@ -4,12 +4,11 @@
   <meta charset="UTF-8">
   <title>Arboretum</title>
   <link rel="stylesheet" href="src/style.css">
-  <script src="https://requirejs.org/docs/release/2.3.5/minified/require.js"></script>
   <script src="main.js"></script>
 </head>
 
 <body>
   <div id="elm"></div>
-    <script src="src/port.js"> </script>
+    <script src="bundle.js"> </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Arboretum</title>
+  <link rel="stylesheet" href="src/style.css">
+  <script src="https://requirejs.org/docs/release/2.3.5/minified/require.js"></script>
+  <script src="main.js"></script>
+</head>
+
+<body>
+  <div id="elm"></div>
+    <script src="src/port.js"> </script>
+</body>
+</html>

--- a/makearb.sh
+++ b/makearb.sh
@@ -1,0 +1,2 @@
+browserify src/port.js -o bundle.js
+elm make --output main.js src/Main.elm

--- a/src/Environment.elm
+++ b/src/Environment.elm
@@ -1,10 +1,13 @@
-module Environment exposing (Env, lookup, extend, varsToEnv)
+
+module Environment exposing (Env, lookup, lookupType, lookupName, extend, varsToEnv, replaceType, replaceTerm, envToVars, addOrModify)
 
 import List exposing (map)
-import Types exposing (Term(..), Var)
+import Types exposing (Term(..), Var, VType(..))
+type alias Env = List (String, Term, VType)
 
-type alias Env = List (String, Term)
-
+{-
+  Note: It might be useful combine lookup and lookupType into a single function.
+-}
 
 lookup : Env -> String -> Maybe Term
 lookup e s =
@@ -12,11 +15,16 @@ lookup e s =
     [] ->
       Nothing
 
-    (id, t) :: vs ->
+    (id, t, vt) :: vs ->
       if id == s then
         Just t
       else lookup vs s
 
+lookupType : Env -> String -> Maybe VType
+lookupType e s =
+  case e of
+    [] ->
+      Nothing
 
     (id, t, vt) :: vs ->
       if id == s then
@@ -93,4 +101,15 @@ extend e v =
 -- we may eventually want to move away from var, but this stopgap works for now
 varsToEnv : List Var -> Env
 varsToEnv vs =
-  map (\v -> (v.name, v.term)) vs
+  map (\v -> (v.name, v.term, v.vtype)) vs
+
+{-
+  The reverse of varsToEnv.
+-}
+envToVars : Env -> List Var
+envToVars env =
+  case env of
+    t :: ts ->
+      case t of
+        (a, b, c) -> [{name=a,term=b,vtype=c}] ++ envToVars ts
+    _ -> []

--- a/src/Environment.elm
+++ b/src/Environment.elm
@@ -75,9 +75,10 @@ replaceType e s vt =
     Nothing -> addOrModify e (False, True) (s, EmptyTree, vt) --Can't replace
 
 {-
-  If the variable is part of the environment and either the term of the type
-  is unknown, replace the unknown term/variable with a specific term/variable.
-  Otherwise, insert the variable into the environment.
+  If the variable is part of the environment and, depending on the pair (Bool, Bool)
+  modify the term and/or the type. For instance, the pair (True, False) implies
+  switching the term for a new one, but keeping the type as is.
+  If the variable does not exist, insert it into the environment.
 -}
 addOrModify : Env -> (Bool, Bool) -> (String, Term, VType) -> Env
 addOrModify e flag (s, t, vt) =

--- a/src/Environment.elm
+++ b/src/Environment.elm
@@ -31,7 +31,7 @@ lookupType e s =
       else lookupType vs s
 
 {-
-  This is a bit happy. There are shadowing issues when the user inputs identical
+  This is a bit hacky. There are shadowing issues when the user inputs identical
   terms with different names; we should probably find a better way to do this.
 -}
 lookupName : Env -> Term -> Maybe String

--- a/src/Evaluate.elm
+++ b/src/Evaluate.elm
@@ -160,7 +160,7 @@ eval e t =
         Just (VFun e1 a b) ->
           case evale y of
             Just w ->
-              let e2 = addOrModify e1 (a, valToTerm w, TNone) in
+              let e2 = addOrModify e1 (True, False) (a, valToTerm w, TInt) in
                 eval e2 b
             _ -> Nothing
         _ -> Nothing

--- a/src/Evaluate.elm
+++ b/src/Evaluate.elm
@@ -3,11 +3,10 @@ module Evaluate exposing (..)
 import List exposing (..)
 import List.Extra exposing (elemIndex, getAt)
 import Types exposing (..)
-import Environment exposing (Env, lookup)
-import Typecheck exposing(substitute)
+import Environment exposing (Env, lookup, extend, addOrModify)
 
 -- Val is a value that a term can evaluate to
-type Val = VBool Bool | VInt Int
+type Val = VBool Bool | VInt Int | VFun Env String Term
 
 boolToString : Bool -> String
 boolToString b =
@@ -21,6 +20,7 @@ valToString v =
   case v of
     Just (VBool x) -> boolToString x
     Just (VInt x)  -> String.fromInt x
+    Just (VFun e n t) ->  "\\" ++ n ++ " -> " ++ (termToString t)
     Nothing        -> "Undefined"
 
 
@@ -54,7 +54,7 @@ termToString t =
       "(" ++ (termToString t1) ++ " || " ++ (termToString t2) ++ ")"
 
     Lam t1 t2 ->
-      "(\\ " ++ (termToString t1) ++ " -> " ++ (termToString t2) ++ ")"
+      "(\\" ++ t1 ++ " -> " ++ (termToString t2) ++ ")"
 
     App t1 t2 ->
       "(" ++ (termToString t1) ++ (termToString t2) ++ ")"
@@ -106,6 +106,12 @@ takeOne (mx, my) =
         Just y ->  Just y
         Nothing -> Nothing
 
+valToTerm : Val -> Term
+valToTerm v =
+  case v of
+    VBool b -> CTerm (CBool b)
+    VInt i -> CTerm (CInt i)
+    VFun e s t -> Lam s t
 
 -- evaluates a term
 eval : Env -> Term -> Maybe Val
@@ -145,9 +151,10 @@ eval e t =
     Or x y ->
       wrapBool ( tryBinFn (||) (tryBool (evale x)) (tryBool (evale y)) )
 
-    Lam x y ->
-      evale y
+    -- Lambda gets evaluated to a closure.
+    Lam x y -> Just (VFun e x y)
 
+    --Same as before, except we use a closure rather than substitution.
     App x y ->
       case evale x of
         Just (VFun e1 a b) ->
@@ -155,15 +162,6 @@ eval e t =
             Just w ->
               let e2 = addOrModify e1 (True, False) (a, valToTerm w, TInt) in
                 eval e2 b
-
             _ -> Nothing
-        VTerm v ->
-          let lambda = lookup e v
-            in case lambda of
-              Just (Lam w z) ->
-                case w of
-                  VTerm n -> evale (substitute z y n)
-                  _ -> Nothing
-              _ -> Nothing
         _ -> Nothing
     _ -> Nothing

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -4,7 +4,7 @@ import Browser exposing (Document)
 import Html exposing (Html, button, div, text, h1, h3, input, span, textarea, br, p)
 import Html.Events exposing (onClick, onInput)
 import Html.Attributes exposing (..)
-import List exposing (map,head,tail)
+import List exposing (map,head,tail,reverse)
 import Debug exposing (toString)
 import Json.Decode as Decode exposing (Decoder, field, bool, int, string)
 import String exposing (split)
@@ -163,7 +163,7 @@ binDecoder comb =
   field "children" (Decode.list exprDecoder)
     |> Decode.andThen
       (\ts ->
-        case ts of
+        case reverse ts of
           t1::t2::tr ->
             Decode.succeed (binCombiner comb t1 ([t2] ++ tr))
           _ ->
@@ -174,7 +174,7 @@ binDecoder comb =
 This function needs at least one item in list to return a Term; the Elm
 community seems to like this approach of passing a 'first' input followed
 by the remaineder to ensure that at least one input is recieved.  I'm still
-not sure how I feel.
+not sure how I feel about this.
 -}
 binCombiner : (Term -> Term -> Term) -> Term -> List Term -> Term
 binCombiner comb first ts =
@@ -182,7 +182,7 @@ binCombiner comb first ts =
     [] ->
       first
     t::tr ->
-      comb first (binCombiner comb t tr)
+      comb (binCombiner comb t tr) first
 
 addDecoder = binDecoder (\t1 t2 -> Plus t1 t2)
 subtDecoder = binDecoder (\t1 t2 -> Minus t1 t2)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -80,7 +80,7 @@ update msg model =
       case r of
         Ok ts ->
           let
-            vs = map (\(n,t) -> {name=n, term=t, vtype=typecheck t}) ts
+            vs = map (\(n,t) -> {name=n, term=t, vtype=TInt}) ts
             ris = genRenderInfos 3 vs
           in
             ({ model | vars = vs, renderTreeInfos = ris }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,7 +6,7 @@ import Html.Events exposing (onClick, onInput)
 import Html.Attributes exposing (..)
 import List exposing (map,head,tail)
 import Debug exposing (toString)
-import Json.Decode as Decode
+import Json.Decode as Decode exposing (Decoder, field, bool, int, string)
 
 import Tokenizer
 import Parser
@@ -133,6 +133,36 @@ subscriptions _ =
 decodeAst : Decode.Value -> Term
 decodeAst _ = CTerm (CInt 42)
 
+
+assignDecoder : Decoder Term
+assignDecoder = 
+  field "expresssion" exprDecoder
+
+exprDecoder : Decoder Term
+exprDecoder =
+  field "type" string
+    |> Decode.andThen exprSwitch
+
+exprSwitch : String -> Decoder Term
+exprSwitch s =
+  case s of
+    "INT"  -> intDecoder
+    "BOOL" -> boolDecoder
+    --"ADD_EXPR" -> addDecoder
+    _      -> Decode.fail ("unrecognized type: " ++ s)
+
+
+intDecoder : Decoder Term
+intDecoder =
+  field "value" int
+    |> Decode.andThen
+      (\i -> Decode.succeed (CTerm (CInt i)))
+
+boolDecoder : Decoder Term
+boolDecoder =
+  field "value" bool
+    |> Decode.andThen
+      (\b -> Decode.succeed (CTerm (CBool b)))
 
 -- VIEW
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -295,7 +295,7 @@ binCombinerRight comb first ts =
     [] ->
       first
     t::tr ->
-      comb first (binCombiner comb t tr)
+      comb first (binCombinerRight comb t tr)
 
 addDecoder = binDecoder (\t1 t2 -> Plus t1 t2)
 subtDecoder = binDecoder (\t1 t2 -> Minus t1 t2)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -30,7 +30,6 @@ main =
 
 type alias Model =
   { content : String
-  , tokens  : List (List Token)
   , vars       : List Var
   , renderTreeInfos : List RenderTreeInfo
   , errorMsg : String
@@ -40,7 +39,6 @@ type alias Model =
 init : () -> (Model, Cmd Msg)
 init _ =
   ( { content = ""
-    , tokens = [[]]
     , vars = []
     , renderTreeInfos = []
     , errorMsg = ""
@@ -236,9 +234,7 @@ view model =
           ]
           , div [class "tokenizer-parser-container"]
           [
-            h3 [ class "css-title" ] [text "Tokens:"]
-            , div [class "expression-builder"] (printTknsLBL model.tokens)
-            , h3 [ class "css-title" ] [text "Parse Tree:"]
+            h3 [ class "css-title" ] [text "Parse Tree:"]
             , div [class "expression-builder"] (printPT model.vars)
           ]
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -58,8 +58,6 @@ update msg model =
         c = newContent
         t = Tokenizer.tokenize (map (String.words) (String.lines c))
         v = envToVars (Parser.generateEnv [] t)
-        -- v1 = map Parser.parse t
-        -- v = envToVars (Parser.avoidDuplicates (varsToEnv v1))
         rs = genRenderInfos 3 v
       in
       ({ model |

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -252,6 +252,7 @@ exprSwitch s =
     "OR_EXPR" -> orDecoder
     "EQ_EXPR" -> eqDecoder
     "FN_EXPR" -> fnDecoder
+    "APP_EXPR" -> appDecoder
     _      -> Decode.fail ("unrecognized type: " ++ s)
 
 fnDecoder : Decoder Term
@@ -301,6 +302,7 @@ subtDecoder = binDecoder (\t1 t2 -> Minus t1 t2)
 multDecoder = binDecoder (\t1 t2 -> Times t1 t2)
 andDecoder = binDecoder (\t1 t2 -> And t1 t2)
 orDecoder = binDecoder (\t1 t2 -> Or t1 t2)
+appDecoder = binDecoder (\t1 t2 -> App t1 t2)
 
 eqDecoder : Decoder Term
 eqDecoder =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -7,7 +7,7 @@ import Debug exposing (toString)
 
 import Tokenizer
 import Parser
-import Environment exposing (Env, lookup)
+import Environment exposing (Env, lookup, varsToEnv, envToVars)
 import Evaluate
 import Types exposing (..)
 import Typecheck exposing (CheckResult(..), typecheck, checkResultToString, typeToString)
@@ -47,6 +47,8 @@ init _ =
 
 type Msg
   = Change String | IncDepth Int | DecDepth Int
+
+
 
 update : Msg -> Model -> (Model, Cmd Msg)
 update msg model =
@@ -95,7 +97,7 @@ filterUpdate cond upd xs =
 Generates a list of render infos.  This function exists mostly so that render
 infos can recieve ids.
 -}
-genRenderInfos : Int -> List Var -> List RenderTreeInfo
+genRenderInfos : Int -> List Var -> List RenderTreeInfo -- Changed List Var to Env
 genRenderInfos depth vars =
   List.indexedMap
     ( \i var ->
@@ -190,6 +192,8 @@ renderTerm e t =
     , span [ class spanClass ] [ text (checkResultToString checkResult) ]
     ]
 
+-- stringToTerm : String -> Maybe Term
+-- stringToTerm s =
 
 listSubterms : Term -> List Term
 listSubterms t =
@@ -202,7 +206,7 @@ listSubterms t =
     Eq x y ->    [x, y]
     And x y ->   [x, y]
     Or x y ->    [x, y]
-    Lam x y ->   [x, y]
+    Lam x y ->   [VTerm ("\\" ++ x), y]
     App x y ->   [x, y]
     _ ->         []
 
@@ -347,7 +351,7 @@ genRenderTree depth e t =
         Eq x y    -> [gTree x, gTree y]
         And x y   -> [gTree x, gTree y]
         Or x y    -> [gTree x, gTree y]
-        --Lam x y   -> [gTree x, gTree y]
+        -- Lam x y   -> [gTree (VTerm (x)), gTree y]
         App x y   -> [gTree x, gTree y]
         _         -> []
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,3 +1,5 @@
+port module Main exposing (..)
+
 import Browser exposing (Document)
 import Html exposing (Html, button, div, text, h1, h3, input, span, textarea, br)
 import Html.Events exposing (onClick, onInput)
@@ -42,6 +44,9 @@ init _ =
   , Cmd.none )
 
 
+-- PORTS (not really sure where to put these)
+port parseText : String -> Cmd a
+
 
 -- UPDATE
 
@@ -63,7 +68,7 @@ update msg model =
         , tokens = t
         , vars = v
         , renderTreeInfos = rs
-       }, Cmd.none)
+       }, parseText newContent)
 
     IncDepth id ->
       let

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -212,7 +212,7 @@ fnTypeDecoder =
       (\ts ->
         case ts of
           t1::t2::tr ->
-            Decode.succeed (binCombinerRight (\l r -> TFun l r)  t1 ([t2] ++ tr))
+            Decode.succeed (binCombinerRight (\l r -> TFun l r) t1 ([t2] ++ tr))
           _ ->
             Decode.fail "function type has fewer than 2 children"
       )
@@ -225,7 +225,7 @@ basicTypeDecoder =
         case t of
           "Int"  -> Decode.succeed TInt
           "Bool" -> Decode.succeed TBool
-          _      -> Decode.fail ("Invalid bool: " ++ t)
+          _      -> Decode.fail ("Invalid basic type: " ++ t)
       )
 
 assignDecoder : Decoder (String, Term)

--- a/src/Parser.elm
+++ b/src/Parser.elm
@@ -22,19 +22,21 @@ generateEnv e tokens =
   in case tkns of
       Just a ->
         let
-          item = parse a
+          (item, flag) = parse a
           (s, t, vt) = (item.name, item.term, item.vtype)
         in
-          generateEnv (addOrModify e (s, t, vt)) (drop 1 tokens)
+          generateEnv (addOrModify e flag (s, t, vt)) (drop 1 tokens)
       _ -> e
 
-parse : List Token -> Var
+parse : List Token -> (Var, (Bool, Bool))
 parse tokens = case take 2 tokens of
                     [TokVar v,TokAssign] -> let (tree, toks) = expression (drop 2 tokens)
-                                              in {name=v, term=tree, vtype = TNone}
+                                              in ({name=v, term=tree, vtype = TInt}, (True, False))
                     [TokVar v,TokHasType] -> let myType = listToTypeSign (prepareTypeList (drop 2 tokens))
-                                              in {name=v, term=EmptyTree, vtype=myType}
-                    _                    -> {name="",term=EmptyTree, vtype=TNone}
+                                              in case myType of
+                                                Just vt -> ({name=v, term=EmptyTree, vtype=vt}, (False, True))
+                                                Nothing -> ({name=v, term=EmptyTree, vtype=TInt}, (False, False))
+                    _                    -> ({name="",term=EmptyTree, vtype=TInt}, (False, False))
 
 
 tokTypeNameToVType : Token -> Maybe VType
@@ -42,7 +44,6 @@ tokTypeNameToVType t =
   case t of
     TokTypeName "Int" -> Just TInt
     TokTypeName "Bool" -> Just TBool
-    TokTypeName "Any" -> Just TAny
     _ -> Nothing
 
 prepareTypeList : List Token -> List VType

--- a/src/Parser.elm
+++ b/src/Parser.elm
@@ -1,6 +1,7 @@
 module Parser exposing (..)
 
 import List exposing (head,tail,take,drop,foldr)
+import Environment exposing (lookup, Env, replaceType, replaceTerm, addOrModify)
 import Types exposing (..)
 import Debug exposing (toString)
 
@@ -55,6 +56,7 @@ prepareTypeList tokens =
     _ -> []
 
 
+
 twoSidedConnective : Term -> List Token -> TokTSC -> (Term, Term, List Token)
 twoSidedConnective left tokens typeSign = case (left, tokens, typeSign) of
                               -- tsc int
@@ -88,8 +90,13 @@ expression tokens = let (l, tokens2) = expr tokens
                                                 TTSCBool TokOr  -> (Or left right, tokens3)
                                                 TTSCBool TokAnd  -> (And left right, tokens3)
                                                 TTSCBool TokEq  -> (Eq left right, tokens3)
-                        Just TokArrow -> let (body, tokens4) = expression (fromMaybeList(tail tokens2))
-                                      in (Lam l body, tokens4)
+                        Just TokArrow ->
+                                      case l of
+                                        VTerm v -> let
+                                                    (body, tokens4) = expression (fromMaybeList(tail tokens2))
+                                                   in (Lam v body, tokens4)
+                                        _ -> (EmptyTree, []) --Shouldn't hit this case
+
                         _ ->
                           case l of
                             Lam _ _ ->

--- a/src/Tokenizer.elm
+++ b/src/Tokenizer.elm
@@ -24,9 +24,6 @@ operator str =
             else if str == "*" then
                 TTSC (TTSCInt TokTimes)
 
-            else if str == "=" then
-                TokAssign
-
             else if str == "==" then
                 TTSC (TTSCBool TokEq)
 
@@ -36,6 +33,12 @@ operator str =
             else if str == "||" then
                 TTSC (TTSCBool TokOr)
 
+            else if str == "=" then
+                TokAssign
+
+            else if str == "::" then
+                TokHasType
+
             else if str == "?" then
                 TokHole
 
@@ -44,7 +47,7 @@ operator str =
 
 
 operators =
-    [ "+", "-", "*", "=", "==", "&&", "||", "?" ]
+    [ "+", "-", "*", "=", "==", "&&", "||", "?", "::" ]
 
 
 isBoolean : String -> Bool
@@ -58,6 +61,17 @@ isBoolean x =
 
         other ->
             False
+
+isTypeName : String -> Bool
+isTypeName x =
+  case x of
+    "Int" ->
+      True
+    "Bool" ->
+      True
+    "Fun" ->
+      True
+    _ -> False
 
 
 stringToBoolean : String -> Bool
@@ -87,7 +101,6 @@ fromMaybeInt x =
     case x of
         Nothing ->
             0
-
         -- should never get called
         Just y ->
             y
@@ -110,6 +123,9 @@ tokenizeLine str =
 
             else if isBoolean x then
                 TokConstBool (stringToBoolean x) :: tokenizeLine xs
+
+            else if isTypeName x then
+                TokTypeName x :: tokenizeLine xs
 
             else if String.filter Char.isDigit x == x && x /= "" then
                 TokConstInt (stringToInt x) :: tokenizeLine xs

--- a/src/Typecheck.elm
+++ b/src/Typecheck.elm
@@ -1,11 +1,8 @@
-module Typecheck exposing (CheckResult(..), VType(..), typeToString, checkResultToString, typecheck, substitute)
+module Typecheck exposing (CheckResult(..), typeToString, checkResultToString, typecheck)
 import List exposing (..)
 import List.Extra exposing (elemIndex, getAt)
-import Types exposing (Const(..), Term(..))
-import Environment exposing (Env, lookup)
-
--- V(alue)Type is a type that a TreeAssembly term can evaluate to
-type VType = TBool | TInt | TLam VType VType
+import Types exposing (Const(..), Term(..), VType(..), getTypeSignature, listToTypeSign, typeSignToList)
+import Environment exposing (Env, lookup, lookupType, lookupName, extend, addOrModify)
 
 
 
@@ -18,7 +15,6 @@ typeToString t =
 
 {-
 CheckResult represents the outcome of typechecking a term
-
 Checks type : The term successfully typechecks to `type`
 Fails argNum expected got output : The terms fails typechecking, where
   `argNum` was of type `got` instead of `expected`.  The term would have
@@ -107,53 +103,33 @@ checkSig sig args =
 
       Nothing -> Invalid
 
+{-
+  Returns the types of the arguments to the binary operations for type checking.
+-}
+getTypeArgs : Env -> Term -> List CheckResult
+getTypeArgs env t =
+  let check = typecheck env in
+    case t of
+      Plus x y  -> (check x) :: (check y) :: []
+      Minus x y -> (check x) :: (check y) :: []
+      Times x y -> (check x) :: (check y) :: []
+      Eq x y    -> (check x) :: (check y) :: []
+      And x y   -> (check x) :: (check y) :: []
+      Or x y    -> (check x) :: (check y) :: []
+      _         -> []
 
-substitute : Term -> Term -> String -> Term
-substitute old new n =
-  case old of
-    CTerm c -> CTerm c
-    VTerm v -> if n == v then new else VTerm v
-    Lam t1 t2 ->
-      case t1 of
-        VTerm v -> if n == v then Lam t1 t2 else Lam t1 (substitute t2 new n)
-        _ -> Lam t1 t2
-    App t1 t2 -> App (substitute t1 new n) (substitute t2 new n)
-    Plus t1 t2 -> Plus (substitute t1 new n) (substitute t2 new n)
-    Minus t1 t2 -> Minus (substitute t1 new n) (substitute t2 new n)
-    Times t1 t2 -> Times (substitute t1 new n) (substitute t2 new n)
-    Eq t1 t2 -> Eq (substitute t1 new n) (substitute t2 new n)
-    And t1 t2 -> And (substitute t1 new n) (substitute t2 new n)
-    Or t1 t2 -> Or (substitute t1 new n) (substitute t2 new n)
-    any -> any
-
-
-typeCheckApp : Env -> Term -> CheckResult
-typeCheckApp env t =
-  case t of
-    App x y ->
-      case x of
-        Lam w z ->
-          case w of
-            VTerm n -> typecheck env (substitute z y n)
-            _ -> Invalid
-        VTerm v ->
-          let lambda = lookup env v
-            in case lambda of
-              Just (Lam w z) ->
-                case w of
-                  VTerm n -> typecheck env (substitute z y n)
-                  _ -> Invalid
-              _ -> Invalid
-        _ -> Invalid
-    _ -> Invalid
-
-
-getTypeSignature : Env -> Term -> List VType
-getTypeSignature env t =
+{-
+  Inserts a lambda's argument into the environment (takes into account nested lambdas).
+-}
+insertArgs : Env -> Term -> Env
+insertArgs env t =
   case t of
     Lam a b -> insertArgs (extend env (a, EmptyTree, TInt)) b --Defaults to int
     _ -> env
 
+{-
+  Uses checkSig for everything except VTerm, Lam, and App.
+-}
 typecheck : Env -> Term -> CheckResult
 typecheck env t =
   let
@@ -170,12 +146,11 @@ typecheck env t =
         case lookup env v of
           Just sub -> check sub
           Nothing  -> Invalid
-      --Lam a b -> checkFunc (getTypeSignature env b)
+
       Lam a b ->
-        case (typecheck env a, typecheck env b) of
-          (Checks x, Checks y) -> Checks (TLam x y)
-          _ -> Invalid
-      App x y -> typeCheckApp env t
+        typecheckLam env t
+
+      App x y -> typecheckApp env t
       _ -> checkSig sig args
 
 {-

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -37,7 +37,7 @@ getTypeSignature t =
     Plus x y -> Just (TFun TInt (TFun TInt TInt))
     Minus x y -> Just (TFun TInt (TFun TInt TInt))
     Times x y -> Just (TFun TInt (TFun TInt TInt))
-    Eq x y -> Just (TFun TBool (TFun TInt TInt))
+    Eq x y -> Just (TFun TInt (TFun TInt TBool))
     And x y -> Just (TFun TBool (TFun TBool TBool))
     Or x y -> Just (TFun TBool (TFun TBool TBool))
     Lam x y -> getTypeSignature y --Possibly useful for nested functions

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -2,8 +2,9 @@ module Types exposing (..)
 
 type Tree a = Node a (List (Tree a))
 
-type Token = TTSC TokTSC | TokAssign | TokLParen | TokRParen | TokHole | TokVar String
-             | TokConstInt Int | TokConstBool Bool | TokInvalid | TokBackSlash | TokArrow | TokEnd
+type Token = TTSC TokTSC | TokAssign | TokLParen | TokRParen | TokHole |
+              TokVar String | TokHasType | TokConstInt Int | TokConstBool Bool |
+              TokInvalid | TokBackSlash | TokArrow | TokEnd | TokTypeName String
 
 type TokTSC = TTSCInt TokTSCInt | TTSCBool TokTSCBool
 type TokTSCInt = TokPlus | TokMinus | TokTimes
@@ -11,7 +12,7 @@ type TokTSCBool = TokEq | TokAnd | TokOr
 
 type Const = CBool Bool | CInt Int
 type Term = CTerm Const | VTerm String | Plus Term Term | Minus Term Term | Times Term Term
-            | Eq Term Term | And Term Term | Or Term Term | Lam Term Term | App Term Term
+            | Eq Term Term | And Term Term | Or Term Term | Lam String Term | App Term Term
             | MissingInt | MissingBool | Missing | EmptyTree
 
 -- V(alue)Type is a type that a TreeAssembly term can evaluate to

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -40,7 +40,7 @@ getTypeSignature t =
     Eq x y -> Just (TFun TInt (TFun TInt TBool))
     And x y -> Just (TFun TBool (TFun TBool TBool))
     Or x y -> Just (TFun TBool (TFun TBool TBool))
-    Lam x y -> getTypeSignature y --Possibly useful for nested functions
+    Lam x y -> Nothing --Need to work on this.
     App x y -> Nothing --Might have to change this later on
     _ -> Nothing
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -15,9 +15,8 @@ type Term = CTerm Const | VTerm String | Plus Term Term | Minus Term Term | Time
             | Eq Term Term | And Term Term | Or Term Term | Lam String Term | App Term Term
             | MissingInt | MissingBool | Missing | EmptyTree
 
--- V(alue)Type is a type that a TreeAssembly term can evaluate to
-{-
-  TAny may be used when the type can be either int or bool (discuss)
+{- 
+  V(alue)Type is a type that a TreeAssembly term can evaluate to
 -}
 type VType = TBool | TInt | TFun VType VType
 

--- a/src/parser/lexing.js
+++ b/src/parser/lexing.js
@@ -1,0 +1,75 @@
+"use strict"
+
+const chevrotain = require("chevrotain")
+const Lexer = chevrotain.Lexer
+const createToken = chevrotain.createToken
+
+// the vocabulary will be exported and used in the Parser definition.
+const tokenVocabulary = {}
+
+// createToken is used to create a TokenType
+// The Lexer's output will contain an array of token Objects created by metadata
+const Identifier = createToken({ name: "Identifier", pattern: /[a-zA-Z]\w*/ })
+
+const Integer = createToken({ name: "Integer", pattern: /0|[1-9]\d*/ })
+
+const Boolean = createToken({
+    name: "Boolean",
+    pattern: /True|False/,
+    longer_alt: Identifier
+    })
+
+const Equivalence = createToken({name: "Equivalence", pattern: /==/ })
+const Assignment = createToken({ name: "Assignment", pattern: /=/ })
+
+const Addition = createToken({name: "Addition", pattern: /\+/ })
+const Subtraction = createToken({name: "Subtraction", pattern: /-/ })
+const Multiplication = createToken({name: "Multiplication", pattern: /\*/ })
+
+const LogicalOR = createToken({name: "LogicalOR", pattern: /\|\|/ })
+const LogicalAND = createToken({name: "LogicalAND", pattern: /&&/ })
+
+const LParen = createToken({ name: "LParen", pattern: /\(/ })
+const RParen = createToken({ name: "RParen", pattern: /\)/ })
+const WhiteSpace = createToken({
+    name: "WhiteSpace",
+    pattern: /\s+/,
+    group: Lexer.SKIPPED
+})
+
+// The order of tokens is important
+const allTokens = [
+    WhiteSpace,
+    Boolean,
+    Identifier,
+    Integer,
+    Equivalence,
+    Assignment,
+    Addition,
+    Subtraction,
+    Multiplication,
+    LogicalOR,
+    LogicalAND,
+    LParen,
+    RParen
+]
+
+const TreeLexer = new Lexer(allTokens)
+
+allTokens.forEach(tokenType => {
+    tokenVocabulary[tokenType.name] = tokenType
+})
+
+module.exports = {
+    tokenVocabulary: tokenVocabulary,
+
+    lex: function(inputText) {
+        const lexingResult = TreeLexer.tokenize(inputText)
+
+        if (lexingResult.errors.length > 0) {
+            throw Error("Sad Sad Panda, lexing errors detected")
+        }
+
+        return lexingResult
+    }
+}

--- a/src/parser/lexing.js
+++ b/src/parser/lexing.js
@@ -21,7 +21,13 @@ const Boolean = createToken({
 
 const Lambda = createToken({name: "Lambda", pattern: /\\/ })
 const Arrow = createToken({name: "Arrow", pattern: /->/ })
-const Type = createToken({name: "Type", pattern: /->/ })
+const TypeAssignment = createToken({name: "TypeAssignment", pattern: /::/ })
+
+const BasicType = createToken({
+    name: "BasicType",
+    pattern: /Int|Bool/,
+    longer_alt: Identifier
+    })
 
 const Equivalence = createToken({name: "Equivalence", pattern: /==/ })
 const Assignment = createToken({ name: "Assignment", pattern: /=/ })
@@ -45,10 +51,11 @@ const WhiteSpace = createToken({
 const allTokens = [
     WhiteSpace,
     Boolean,
+    BasicType,
+    Identifier,
     Lambda,
     Arrow,
-    Type,
-    Identifier,
+    TypeAssignment,
     Integer,
     Equivalence,
     Assignment,

--- a/src/parser/lexing.js
+++ b/src/parser/lexing.js
@@ -19,6 +19,10 @@ const Boolean = createToken({
     longer_alt: Identifier
     })
 
+const Lambda = createToken({name: "Lambda", pattern: /\\/ })
+const Arrow = createToken({name: "Arrow", pattern: /->/ })
+const Type = createToken({name: "Type", pattern: /->/ })
+
 const Equivalence = createToken({name: "Equivalence", pattern: /==/ })
 const Assignment = createToken({ name: "Assignment", pattern: /=/ })
 
@@ -41,6 +45,9 @@ const WhiteSpace = createToken({
 const allTokens = [
     WhiteSpace,
     Boolean,
+    Lambda,
+    Arrow,
+    Type,
     Identifier,
     Integer,
     Equivalence,

--- a/src/parser/parsing.js
+++ b/src/parser/parsing.js
@@ -1,0 +1,136 @@
+"use strict"
+
+// Adding a Parser (grammar only, only reads the input without any actions).
+// Using the Token Vocabulary defined in the previous step.
+
+const scriptLexer = require("./lexing")
+const Parser = require("chevrotain").Parser
+const tokenVocabulary = scriptLexer.tokenVocabulary
+
+// individual imports, prefer ES6 imports if supported in your runtime/transpiler...
+const Identifier = tokenVocabulary.Identifier
+const Integer = tokenVocabulary.Integer
+const Boolean = tokenVocabulary.Boolean
+const Equivalence = tokenVocabulary.Equivalence
+const Assignment = tokenVocabulary.Assignment
+const Addition = tokenVocabulary.Addition
+const Subtraction = tokenVocabulary.Subtraction
+const Multiplication = tokenVocabulary.Multiplication
+const LogicalOR = tokenVocabulary.LogicalOR
+const LogicalAND = tokenVocabulary.LogicalAND
+const LParen = tokenVocabulary.LParen
+const RParen = tokenVocabulary.RParen
+
+// ----------------- parser -----------------
+class ScriptParser extends Parser {
+    // A config object as a constructor argument is normally not needed.
+    // Our tutorial scenario requires a dynamic configuration to support step3 without duplicating code.
+    constructor(config) {
+        super(tokenVocabulary, config)
+
+        // for conciseness
+        const $ = this
+
+        $.RULE("assignmentStatement", () => {
+            $.CONSUME(Identifier)
+            $.CONSUME(Assignment)
+            $.SUBRULE($.expression)
+        })
+
+        $.RULE("expression", () => {
+            $.SUBRULE($.eqExpression)
+        })
+
+        $.RULE("eqExpression", () => {
+            $.SUBRULE($.orExpression)
+            $.OPTION( () => {
+                $.CONSUME(Equivalence)
+                $.SUBRULE2($.orExpression)
+            })
+        })
+
+        $.RULE("orExpression", () => {
+            $.SUBRULE($.andExpression)
+            $.MANY( () => {
+                $.CONSUME(LogicalOR)
+                $.SUBRULE2($.andExpression)
+            })
+        })
+        $.RULE("andExpression", () => {
+            $.SUBRULE($.subtExpression)
+            $.MANY( () => {
+                $.CONSUME(LogicalAND)
+                $.SUBRULE2($.subtExpression)
+            })
+        })
+
+        $.RULE("subtExpression", () => {
+            $.SUBRULE($.addExpression)
+            $.MANY( () => {
+                $.CONSUME(Subtraction)
+                $.SUBRULE2($.addExpression)
+            })
+        })
+
+        $.RULE("addExpression", () => {
+            $.SUBRULE($.multExpression)
+            $.MANY( () => {
+                $.CONSUME(Addition)
+                $.SUBRULE2($.multExpression)
+            })
+        })
+
+        $.RULE("multExpression", () => {
+            $.SUBRULE($.atomicExpression)
+            $.MANY( () => {
+                $.CONSUME(Multiplication)
+                $.SUBRULE2($.atomicExpression)
+            })
+        })
+
+        $.RULE("atomicExpression", () => {
+            $.OR([
+                { ALT: () => {
+                    $.CONSUME(LParen)
+                    $.SUBRULE($.expression)
+                    $.CONSUME(RParen)
+                }},
+                { ALT: () => $.CONSUME(Integer) },
+                { ALT: () => $.CONSUME(Boolean) },
+                { ALT: () => $.CONSUME(Identifier) }
+            ])
+        })
+
+
+        // very important to call this after all the rules have been defined.
+        // otherwise the parser may not work correctly as it will lack information
+        // derived during the self analysis phase.
+        this.performSelfAnalysis()
+    }
+}
+
+// We only ever need one as the parser internal state is reset for each new input.
+const parserInstance = new ScriptParser()
+
+module.exports = {
+    parserInstance: parserInstance,
+
+    ScriptParser: ScriptParser,
+
+    parse: function(inputText) {
+        const lexResult = scriptLexer.lex(inputText)
+
+        // ".input" is a setter which will reset the parser's internal's state.
+        parserInstance.input = lexResult.tokens
+
+        // No semantic actions so this won't return anything yet.
+        parserInstance.assignmentStatement()
+
+        if (parserInstance.errors.length > 0) {
+            throw Error(
+                "Sad sad panda, parsing errors detected!\n" +
+                    parserInstance.errors[0].message
+            )
+        }
+    }
+}

--- a/src/parser/parsing.js
+++ b/src/parser/parsing.js
@@ -75,7 +75,19 @@ class ScriptParser extends Parser {
         })
 
         $.RULE("expression", () => {
-            $.SUBRULE($.eqExpression)
+            $.SUBRULE($.fnExpression)
+        })
+        
+        $.RULE("fnExpression", () => {
+            $.OR([
+                { ALT: () => {
+                    $.CONSUME(Lambda)
+                    $.CONSUME(Identifier)
+                    $.CONSUME(Arrow)
+                    $.SUBRULE($.eqExpression)
+                }}, 
+                { ALT: () => { $.SUBRULE2($.eqExpression) }}, 
+            ])
         })
 
         $.RULE("eqExpression", () => {

--- a/src/parser/parsing.js
+++ b/src/parser/parsing.js
@@ -128,7 +128,7 @@ module.exports = {
 
         if (parserInstance.errors.length > 0) {
             throw Error(
-                "Sad sad panda, parsing errors detected!\n" +
+                "Parsing Error:\n" +
                     parserInstance.errors[0].message
             )
         }

--- a/src/parser/parsing.js
+++ b/src/parser/parsing.js
@@ -130,9 +130,16 @@ class ScriptParser extends Parser {
         })
 
         $.RULE("multExpression", () => {
-            $.SUBRULE($.atomicExpression)
+            $.SUBRULE($.appExpression)
             $.MANY( () => {
                 $.CONSUME(Multiplication)
+                $.SUBRULE2($.appExpression)
+            })
+        })
+
+        $.RULE("appExpression", () => {
+            $.SUBRULE($.atomicExpression)
+            $.MANY( () => {
                 $.SUBRULE2($.atomicExpression)
             })
         })

--- a/src/parser/visitor.js
+++ b/src/parser/visitor.js
@@ -165,7 +165,7 @@ module.exports = {
 
         if (parserInstance.errors.length > 0) {
             throw Error(
-                "Sad sad panda, parsing errors detected!\n" +
+                "Parse Error:\n" +
                     parserInstance.errors[0].message
             )
         }

--- a/src/parser/visitor.js
+++ b/src/parser/visitor.js
@@ -1,0 +1,177 @@
+"use strict"
+
+
+const scriptLexer = require("./lexing")
+// re-using the parser implemented in step two.
+const parser = require("./parsing")
+const SelectParser = parser.ScriptParser
+
+// A new parser instance with CST output (enabled by default).
+const parserInstance = new SelectParser([])
+// The base visitor class can be accessed via the a parser instance.
+const BaseScriptVisitor = parserInstance.getBaseCstVisitorConstructor()
+
+
+class ToAstVisitor extends BaseScriptVisitor {
+    constructor() {
+        super()
+        this.validateVisitor()
+    }
+
+    assignmentStatement(ctx) {
+        const id = ctx.Identifier[0].image
+
+        const exp = this.visit(ctx.expression)
+
+        return {
+            type: "ASSIGN_STMT",
+            identifier: id,
+            expression: exp
+        }
+    }
+
+    // expression rule is some sort of wrapper right now
+    expression(ctx) {
+        const expr = this.visit(ctx.eqExpression)
+
+        return expr
+    }
+
+    /*
+    This and many of the following visitor rules check to see if more than one
+    subexpression exists to see if the rule was actually used.  If it was, a
+    json node is returned.  Otherwise, the results of visiting further down
+    the tree are returned.
+    */
+    eqExpression(ctx) {
+        if(ctx.orExpression.length > 1) {
+            const lhs = this.visit(ctx.orExpression[0])
+            const rhs = this.visit(ctx.orExpression[1])
+            return {
+                type: "EQ_EXPR",
+                lhs: lhs,
+                rhs: rhs,
+            }
+        }
+        else {
+            return this.visit(ctx.orExpression)
+        }
+    }
+
+    orExpression(ctx) {
+        if(ctx.andExpression.length > 1) {
+            const children = ctx.andExpression.map(node => this.visit(node))
+            return {
+                type: "OR_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.andExpression)
+        }
+    }
+
+    andExpression(ctx) {
+        if(ctx.subtExpression.length > 1) {
+            const children = ctx.subtExpression.map(node => this.visit(node))
+            return {
+                type: "AND_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.subtExpression)
+        }
+    }
+
+    subtExpression(ctx) {
+        if(ctx.addExpression.length > 1) {
+            const children = ctx.addExpression.map(node => this.visit(node))
+            return {
+                type: "SUBT_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.addExpression)
+        }
+    }
+
+    addExpression(ctx) {
+        if(ctx.multExpression.length > 1) {
+            const children = ctx.multExpression.map(node => this.visit(node))
+            return {
+                type: "ADD_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.multExpression)
+        }
+    }
+    
+    multExpression(ctx) {
+        if(ctx.atomicExpression.length > 1) {
+            const children = ctx.atomicExpression.map(node => this.visit(node))
+            return {
+                type: "MULT_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.atomicExpression)
+        }
+    }
+
+    atomicExpression(ctx) {
+        if(ctx.expression) {
+            return this.visit(ctx.expression)
+        }
+        else if(ctx.Integer) {
+            return {
+                type: "INT",
+                value: ctx.Integer[0].image,
+            }
+        }
+        else if(ctx.Boolean) {
+            return {
+                type: "BOOL",
+                value: ctx.Boolean[0].image,
+            }
+        }
+        else if(ctx.Identifier) {
+            return {
+                type: "ID",
+                value: ctx.Identifier[0].image,
+            }
+        }
+    }
+
+}
+
+
+// Our visitor has no state, so a single instance is sufficient.
+const toAstVisitorInstance = new ToAstVisitor()
+
+module.exports = {
+    toAst: function(inputText) {
+        const lexResult = scriptLexer.lex(inputText)
+
+        // ".input" is a setter which will reset the parser's internal's state.
+        parserInstance.input = lexResult.tokens
+
+        // Automatic CST created when parsing
+        const cst = parserInstance.assignmentStatement()
+
+        if (parserInstance.errors.length > 0) {
+            throw Error(
+                "Sad sad panda, parsing errors detected!\n" +
+                    parserInstance.errors[0].message
+            )
+        }
+
+        const ast = toAstVisitorInstance.visit(cst)
+
+        return ast
+    }
+}

--- a/src/parser/visitor.js
+++ b/src/parser/visitor.js
@@ -94,9 +94,25 @@ class ToAstVisitor extends BaseScriptVisitor {
 
     // expression rule is some sort of wrapper right now
     expression(ctx) {
-        const expr = this.visit(ctx.eqExpression)
+        const expr = this.visit(ctx.fnExpression)
 
         return expr
+    }
+
+    fnExpression(ctx) {
+        if(ctx.Lambda) {
+            const variable = ctx.Identifier[0].image
+            const body = this.visit(ctx.eqExpression)
+
+            return {
+                type: "FN_EXPR",
+                variable: variable,
+                body: body,
+            }
+        }
+        else {
+            return this.visit(ctx.eqExpression)
+        }
     }
 
     /*

--- a/src/parser/visitor.js
+++ b/src/parser/visitor.js
@@ -11,6 +11,18 @@ const parserInstance = new SelectParser([])
 // The base visitor class can be accessed via the a parser instance.
 const BaseScriptVisitor = parserInstance.getBaseCstVisitorConstructor()
 
+function parseBool(string) {
+    if(string === 'True') {
+        return true
+    }
+    else if(string === 'False') {
+        return false
+    }
+    else {
+        throw "Parsing boolean from string failed!"
+    }
+}
+
 
 class ToAstVisitor extends BaseScriptVisitor {
     constructor() {
@@ -130,13 +142,13 @@ class ToAstVisitor extends BaseScriptVisitor {
         else if(ctx.Integer) {
             return {
                 type: "INT",
-                value: ctx.Integer[0].image,
+                value: parseInt(ctx.Integer[0].image),
             }
         }
         else if(ctx.Boolean) {
             return {
                 type: "BOOL",
-                value: ctx.Boolean[0].image,
+                value: parseBool(ctx.Boolean[0].image),
             }
         }
         else if(ctx.Identifier) {

--- a/src/parser/visitor.js
+++ b/src/parser/visitor.js
@@ -189,10 +189,23 @@ class ToAstVisitor extends BaseScriptVisitor {
     }
     
     multExpression(ctx) {
+        if(ctx.appExpression.length > 1) {
+            const children = ctx.appExpression.map(node => this.visit(node))
+            return {
+                type: "MULT_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.appExpression)
+        }
+    }
+
+    appExpression(ctx) {
         if(ctx.atomicExpression.length > 1) {
             const children = ctx.atomicExpression.map(node => this.visit(node))
             return {
-                type: "MULT_EXPR",
+                type: "APP_EXPR",
                 children: children,
             }
         }

--- a/src/port.js
+++ b/src/port.js
@@ -19,10 +19,9 @@ will get invoked/called when we send a cmd message out via Elm.
 app.ports.parseText.subscribe(function(text) {
     try {
         const ast = toAst(text)
-        console.log(ast)
         app.ports.gotAst.send(ast)
     }
     catch(error) {
-        
+
     }
 });

--- a/src/port.js
+++ b/src/port.js
@@ -1,0 +1,13 @@
+var app = Elm.Main.init({
+    node: document.getElementById('elm')
+});  
+
+
+/*
+Methods we declared as 'port' in Elm will be available on app.ports that
+will get invoked/called when we send a cmd message out via Elm.
+*/
+app.ports.parseText.subscribe(function(text) {
+    console.log(text);                               // Word from Elm
+    //1app.ports.toElm.send("message from js");        // Sending to the Elm sub
+});

--- a/src/port.js
+++ b/src/port.js
@@ -1,6 +1,6 @@
 "use strict"
 
-toAst = require("parser/visitor").toAst
+const toAst = require("./parser/visitor").toAst
 
 var app = Elm.Main.init({
     node: document.getElementById('elm')
@@ -12,6 +12,11 @@ Methods we declared as 'port' in Elm will be available on app.ports that
 will get invoked/called when we send a cmd message out via Elm.
 */
 app.ports.parseText.subscribe(function(text) {
-    const ast = toAST(text)
-    console.log(ast)
+    try {
+        const ast = toAst(text)
+        console.log(ast)
+    }
+    catch(error) {
+        
+    }
 });

--- a/src/port.js
+++ b/src/port.js
@@ -1,3 +1,7 @@
+"use strict"
+
+toAst = require("parser/visitor").toAst
+
 var app = Elm.Main.init({
     node: document.getElementById('elm')
 });  
@@ -8,6 +12,6 @@ Methods we declared as 'port' in Elm will be available on app.ports that
 will get invoked/called when we send a cmd message out via Elm.
 */
 app.ports.parseText.subscribe(function(text) {
-    console.log(text);                               // Word from Elm
-    //1app.ports.toElm.send("message from js");        // Sending to the Elm sub
+    const ast = toAST(text)
+    console.log(ast)
 });

--- a/src/port.js
+++ b/src/port.js
@@ -16,12 +16,13 @@ var app = Elm.Main.init({
 Methods we declared as 'port' in Elm will be available on app.ports that
 will get invoked/called when we send a cmd message out via Elm.
 */
-app.ports.parseText.subscribe(function(text) {
+app.ports.parseLines.subscribe(function(lines) {
     try {
-        const ast = toAst(text)
-        app.ports.gotAst.send(ast)
+        const asts = lines.map(l => toAst(l))
+        console.log(asts)
+        app.ports.gotAst.send(asts)
     }
     catch(error) {
-
+        console.log(error)
     }
 });

--- a/src/port.js
+++ b/src/port.js
@@ -1,5 +1,10 @@
 "use strict"
 
+/*
+ * this file is the seam along which the language interpreter (written in Elm)
+ * and the parser (written in JavaScript/Chevrotain) communicate
+ */
+
 const toAst = require("./parser/visitor").toAst
 
 var app = Elm.Main.init({
@@ -15,6 +20,7 @@ app.ports.parseText.subscribe(function(text) {
     try {
         const ast = toAst(text)
         console.log(ast)
+        app.ports.gotAst.send(ast)
     }
     catch(error) {
         

--- a/src/port.js
+++ b/src/port.js
@@ -19,10 +19,9 @@ will get invoked/called when we send a cmd message out via Elm.
 app.ports.parseLines.subscribe(function(lines) {
     try {
         const asts = lines.map(l => toAst(l))
-        console.log(asts)
         app.ports.gotAst.send(asts)
     }
     catch(error) {
-        console.log(error)
+
     }
 });

--- a/tests/EvaluateTests.elm
+++ b/tests/EvaluateTests.elm
@@ -66,7 +66,7 @@ suite =
               |> eval env
               |> Expect.equal (Just (VBool False))
 
-      {-, test "variable substitution" <|
+      , test "variable substitution" <|
         \_ ->
           let
             env = [("x", CTerm (CInt 9), TInt)]
@@ -91,6 +91,6 @@ suite =
           in
             App (Lam "x" (Plus (VTerm "x") (CTerm (CInt 3)))) (CTerm (CInt 5))
               |> eval env
-              |> Expect.equal (Just (VInt 8))-}
+              |> Expect.equal (Just (VInt 8))
       ]
     ]

--- a/tests/TypecheckTests.elm
+++ b/tests/TypecheckTests.elm
@@ -4,7 +4,7 @@ import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import Test exposing (..)
 
-import Typecheck exposing (CheckResult(..), VType(..), typecheck)
+import Typecheck exposing (CheckResult(..), typecheck)
 import Environment exposing (Env)
 import Types exposing (..)
 
@@ -51,7 +51,7 @@ suite =
       , test "variables evaluate to their types" <|
         \_ ->
           let
-            env = [ ( "a", CTerm (CInt 0) ) ]
+            env = [ ( "a", CTerm (CInt 0) , TInt) ]
           in
             VTerm "a"
               |> typecheck env


### PR DESCRIPTION
Observations:
- Type inference is needed to verify the correctness type signatures. Currently, user's type signatures for functions are assumed to be correct.
- The "checksig" should be refactored to work with a larger variety of functions (more arguments).

Note:
I wrote some (unnecessary) code for tokenizing and parsing type signatures, but the focus of this pull request should be on the work I did on Environment, Types, Evaluate, and Typecheck. Type checking lambdas is really basic right now because I could not figure out a way to check the correctness of a type signature without implementing some sort of type inference, and the way I was going about implementing type inference did not work so I dropped it for now. Type inference should be the next step moving forward with lambdas.