### PR TITLE
Tuples typechecking, evaluation and render

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,3 +1,5 @@
+module Main exposing (..)
+
 import Browser exposing (Document)
 import Html exposing (Html, button, div, text, h1, h3, input, span, textarea, br)
 import Html.Events exposing (onClick, onInput)
@@ -55,7 +57,12 @@ update msg model =
       let
         c = newContent
         t = Tokenizer.tokenize (map (String.words) (String.lines c))
-        v = map Parser.parse t
+        -- v = map Parser.parse t
+        v = [ {name="a",term=(CTerm (CInt 1))}, 
+              {name="b",term=(Lam (VTerm "a") (Plus (VTerm "a") (CTerm (CInt 1)))) },
+              {name="c",term=(App (VTerm "b") (VTerm "a"))},
+              {name="d",term=(Plus (CTerm (CInt 10)) (CTerm(CBool True)))},
+              {name="e",term=(Tuple (CTerm (CInt 1)) (VTerm "c") )}]
         rs = genRenderInfos 3 v
       in
       ({ model |
@@ -204,6 +211,7 @@ listSubterms t =
     Or x y ->    [x, y]
     Lam x y ->   [x, y]
     App x y ->   [x, y]
+    Tuple x y -> [x, y]
     _ ->         []
 
 renderSubtermsRec : Int -> List Term -> CheckResult -> List (Html Msg)
@@ -270,6 +278,7 @@ renderTermInline result t =
         Or _ _    -> "||"
         Lam _ _   -> "->"
         App _ _   -> " "
+        Tuple _ _ -> ","
         _         -> ""
 
     subterms = renderSubterms argTerms result
@@ -278,7 +287,10 @@ renderTermInline result t =
       True ->
         case subterms of
           x :: xs ->
-            span [] ([x, text (" " ++ opStr)] ++ xs)
+            case t of 
+              Tuple _ _ -> span [] ([text ("(")] ++ [x, text (" " ++ opStr)] ++ xs ++ [text (")")]) 
+              _         -> span [] ([x, text (" " ++ opStr)] ++ xs)
+            
           _ ->
             text "rendering error"
       False ->
@@ -347,8 +359,9 @@ genRenderTree depth e t =
         Eq x y    -> [gTree x, gTree y]
         And x y   -> [gTree x, gTree y]
         Or x y    -> [gTree x, gTree y]
-        --Lam x y   -> [gTree x, gTree y]
+        -- Lam x y   -> [gTree x, gTree y]
         App x y   -> [gTree x, gTree y]
+        Tuple x y -> [gTree x, gTree y]
         _         -> []
 
     n =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-module Main exposing (..)
-=======
 port module Main exposing (..)
->>>>>>> origin
 
 import Browser exposing (Document)
 import Html exposing (Html, button, div, text, h1, h3, input, span, textarea, br, p)
@@ -62,19 +58,7 @@ update msg model =
   case msg of
     Change newContent ->
       let
-<<<<<<< HEAD
-        c = newContent
-        t = Tokenizer.tokenize (map (String.words) (String.lines c))
-        -- v = map Parser.parse t
-        v = [ {name="a",term=(CTerm (CInt 1))}, 
-              {name="b",term=(Lam (VTerm "a") (Plus (VTerm "a") (CTerm (CInt 1)))) },
-              {name="c",term=(App (VTerm "b") (VTerm "a"))},
-              {name="d",term=(Plus (CTerm (CInt 10)) (CTerm(CBool True)))},
-              {name="e",term=(Tuple (CTerm (CInt 1)) (VTerm "c") )}]
-        rs = genRenderInfos 3 v
-=======
         lines = split "\n" newContent
->>>>>>> origin
       in
         ({ model | content = newContent }, parseLines lines)
 

--- a/src/Typecheck.elm
+++ b/src/Typecheck.elm
@@ -5,7 +5,7 @@ import Types exposing (Const(..), Term(..))
 import Environment exposing (Env, lookup)
 
 -- V(alue)Type is a type that a TreeAssembly term can evaluate to
-type VType = TBool | TInt | TLam VType VType
+type VType = TBool | TInt | TLam VType VType | TTuple VType VType
 
 
 
@@ -15,6 +15,7 @@ typeToString t =
     TBool -> "Bool"
     TInt  -> "Int"
     TLam a b -> "Lam" ++ " " ++ (typeToString a) ++ " " ++ (typeToString b)
+    TTuple a b -> "Tuple" ++ " " ++ (typeToString a) ++ " " ++ (typeToString b)
 
 {-
 CheckResult represents the outcome of typechecking a term
@@ -167,6 +168,7 @@ getTypeSignature env t =
     Eq _ _    -> [TInt, TInt, TBool]
     And _ _   -> [TBool, TBool, TBool]
     Or _ _    -> [TBool, TBool, TBool]
+    
     _         -> []
 
 
@@ -200,4 +202,9 @@ typecheck env t =
           (Checks x, Checks y) -> Checks (TLam x y)
           _ -> Invalid
       App x y -> typeCheckApp env t
+      Tuple a b ->
+        case (typecheck env a, typecheck env b) of
+          (Checks x, Checks y) -> Checks (TTuple x y)
+          _ -> Invalid
+
       _ -> checkSig sig args

--- a/src/Typecheck.elm
+++ b/src/Typecheck.elm
@@ -154,9 +154,22 @@ typecheck env t =
       App x y -> typecheckApp env t
 
       Tuple a b ->
-        case (typecheck env a, typecheck env b) of
-          (Checks x, Checks y) -> Checks (TTuple x y)
-          _ -> Invalid
+        case (typecheck env m, typecheck env n) of
+          -- Checks a
+          (Checks a, Checks x)            -> Checks (TTuple a x)
+          (Checks a, Fails w x y z)       -> Fails 2 (TTuple a x) (TTuple a y) (TTuple a z)
+          (Checks a, Partial x)           -> Partial (TTuple a x)
+          -- Fails a
+          (Fails a b c d, Checks x)       -> Fails 1 (TTuple b x) (TTuple c x) (TTuple d x)
+          (Fails a b c d, Fails w x y z)  -> Fails 1 (TTuple b x) (TTuple c y) (TTuple d z)  -- should put red on both terms (c,y)
+          (Fails a b c d, Partial x)      -> Fails 1 (TTuple b x) (TTuple c x) (TTuple d x)
+          -- Partial a
+          (Partial a, Checks x)           -> Partial (TTuple a x)
+          (Partial a, Fails w x y z)      -> Fails 2 (TTuple a x) (TTuple a y) (TTuple a z)
+          (Partial a, Partial x)           -> Partial (TTuple a x)
+          -- Invalid a or x
+          (Invalid, _)                    -> Invalid
+          (_, Invalid)                    -> Invalid
           
       _ -> checkSig sig args
 

--- a/src/Typecheck.elm
+++ b/src/Typecheck.elm
@@ -153,7 +153,7 @@ typecheck env t =
 
       App x y -> typecheckApp env t
 
-      Tuple a b ->
+      Tuple m n ->
         case (typecheck env m, typecheck env n) of
           -- Checks a
           (Checks a, Checks x)            -> Checks (TTuple a x)

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -74,4 +74,4 @@ typeSignToList vt =
     TBool           -> [TBool]
     TInt            -> [TInt]
     TFun vt1 vt2    -> (typeSignToList vt1) ++ (typeSignToList vt2)
-    TTuple vt1 vt2  -> (typeSignToList vt1) ++ (typeSignToList vt2)   -- Will return the tuple as a list. Not ideal, but the function is type sign to list
+    TTuple vt1 vt2  -> [TTuple vt1 vt2 ]

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -12,8 +12,11 @@ type TokTSCBool = TokEq | TokAnd | TokOr
 type Const = CBool Bool | CInt Int
 type Term = CTerm Const | VTerm String | Plus Term Term | Minus Term Term | Times Term Term
             | Eq Term Term | And Term Term | Or Term Term | Lam Term Term | App Term Term
-            | MissingInt | MissingBool | Missing | EmptyTree
+            | MissingInt | MissingBool | Missing | EmptyTree | Tuple Term Term
 
 type alias Var =
   { name: String
   , term: Term }
+
+-- elm repl
+--   env = [("x",CTerm (CInt 4)),("y",Lam (VTerm "x") (Plus (VTerm "x") (CTerm (CInt 1)))),("a",App (VTerm "y") (CTerm (CInt 2))),("b",Plus (CTerm (CInt 1)) (CTerm (CInt 2)))] 


### PR DESCRIPTION
Tuples are implemented as:

```
Term = ... | Tuple Term Term
VType = ... | TTuple VType VType
Val = ... | VTuple Val Val 
```

It will typecheck as long as it is valid (if it holds a var that doesn't exist in the environment, it will not typecheck). Same with the evaluation.

I merged master into this branch to fix all the changes, so there is no conflict

Tested it with dummy input. Still need to parse it using Chevrotain.

