### PR TITLE
Implemented Division and Modulus Operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "chevrotain": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-4.3.3.tgz",
+      "integrity": "sha512-DsmAmF5urXboHHXqEr26Ot//S+l3yrOr7UwwgWQ+aNNlYpmnYK1flxplwJ5cIUgP9toKFsJ0VeLT1sq350A9Hg==",
+      "requires": {
+        "regexp-to-ast": "0.4.0"
+      }
+    },
+    "regexp-to-ast": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
+      "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw=="
+    }
+  }
+}

--- a/src/Evaluate.elm
+++ b/src/Evaluate.elm
@@ -44,6 +44,9 @@ termToString t =
     Times t1 t2 ->
       "(" ++ (termToString t1) ++ " * " ++ (termToString t2) ++ ")"
 
+    Mod t1 t2 ->
+      "(" ++ (termToString t1) ++ " % " ++ (termToString t2) ++ ")"
+
     Eq t1 t2 ->
       "(" ++ (termToString t1) ++ " == " ++ (termToString t2) ++ ")"
 
@@ -138,6 +141,9 @@ eval e t =
 
     Times x y ->
       wrapInt ( tryBinFn (*) (tryInt (evale x)) (tryInt (evale y)) )
+
+    Mod x y ->
+      wrapInt ( tryBinFn (modBy) (tryInt (evale y)) (tryInt (evale x)) )
 
     Eq x y ->
       takeOne

--- a/src/Evaluate.elm
+++ b/src/Evaluate.elm
@@ -44,6 +44,9 @@ termToString t =
     Times t1 t2 ->
       "(" ++ (termToString t1) ++ " * " ++ (termToString t2) ++ ")"
 
+    Div t1 t2 ->
+      "(" ++ (termToString t1) ++ " / " ++ (termToString t2) ++ ")"
+
     Mod t1 t2 ->
       "(" ++ (termToString t1) ++ " % " ++ (termToString t2) ++ ")"
 
@@ -141,6 +144,9 @@ eval e t =
 
     Times x y ->
       wrapInt ( tryBinFn (*) (tryInt (evale x)) (tryInt (evale y)) )
+
+    Div x y ->
+      wrapInt ( tryBinFn (//) (tryInt (evale x)) (tryInt (evale y)) )
 
     Mod x y ->
       wrapInt ( tryBinFn (modBy) (tryInt (evale y)) (tryInt (evale x)) )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -246,6 +246,7 @@ exprSwitch s =
     "ADD_EXPR" -> addDecoder
     "SUBT_EXPR" -> subtDecoder
     "MULT_EXPR" -> multDecoder
+    "MOD_EXPR" -> modDecoder
     "AND_EXPR" -> andDecoder
     "OR_EXPR" -> orDecoder
     "EQ_EXPR" -> eqDecoder
@@ -270,7 +271,6 @@ binDecoder comb =
           _ ->
             Decode.fail "binary expression has fewer than 2 children"
       )
-
 
 {-
 This function needs at least one item in list to return a Term; the Elm
@@ -298,6 +298,7 @@ binCombinerRight comb first ts =
 addDecoder = binDecoder (\t1 t2 -> Plus t1 t2)
 subtDecoder = binDecoder (\t1 t2 -> Minus t1 t2)
 multDecoder = binDecoder (\t1 t2 -> Times t1 t2)
+modDecoder = binDecoder (\t1 t2 -> Mod t1 t2)
 andDecoder = binDecoder (\t1 t2 -> And t1 t2)
 orDecoder = binDecoder (\t1 t2 -> Or t1 t2)
 appDecoder = binDecoder (\t1 t2 -> App t1 t2)
@@ -416,6 +417,7 @@ listSubterms t =
     Plus x y ->  [x, y]
     Minus x y -> [x, y]
     Times x y -> [x, y]
+    Mod x y   -> [x, y]
     Eq x y ->    [x, y]
     And x y ->   [x, y]
     Or x y ->    [x, y]
@@ -477,17 +479,18 @@ renderTermInline result t =
         _         -> True
     opStr =
       case t of
-        CTerm _   -> ""
-        VTerm _   -> ""
-        Plus _ _  -> "+"
-        Minus _ _ -> "-"
-        Times _ _ -> "*"
-        Eq _ _    -> "=="
-        And _ _   -> "&&"
-        Or _ _    -> "||"
-        Lam _ _   -> "->"
-        App _ _   -> " "
-        _         -> ""
+        CTerm _        -> ""
+        VTerm _        -> ""
+        Plus _ _       -> "+"
+        Minus _ _      -> "-"
+        Times _ _      -> "*"
+        Mod _ _        -> "%"
+        Eq _ _         -> "=="
+        And _ _        -> "&&"
+        Or _ _         -> "||"
+        Lam _ _        -> "->"
+        App _ _        -> " "
+        _              -> ""
 
     subterms = renderSubterms argTerms result
   in
@@ -561,6 +564,7 @@ genRenderTree depth e t =
         Plus x y  -> [gTree x, gTree y]
         Minus x y -> [gTree x, gTree y]
         Times x y -> [gTree x, gTree y]
+        Mod x y   -> [gTree x, gTree y]
         Eq x y    -> [gTree x, gTree y]
         And x y   -> [gTree x, gTree y]
         Or x y    -> [gTree x, gTree y]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -246,6 +246,7 @@ exprSwitch s =
     "ADD_EXPR" -> addDecoder
     "SUBT_EXPR" -> subtDecoder
     "MULT_EXPR" -> multDecoder
+    "DIV_EXPR"  -> divDecoder
     "MOD_EXPR" -> modDecoder
     "AND_EXPR" -> andDecoder
     "OR_EXPR" -> orDecoder
@@ -298,6 +299,7 @@ binCombinerRight comb first ts =
 addDecoder = binDecoder (\t1 t2 -> Plus t1 t2)
 subtDecoder = binDecoder (\t1 t2 -> Minus t1 t2)
 multDecoder = binDecoder (\t1 t2 -> Times t1 t2)
+divDecoder = binDecoder (\t1 t2 -> Div t1 t2)
 modDecoder = binDecoder (\t1 t2 -> Mod t1 t2)
 andDecoder = binDecoder (\t1 t2 -> And t1 t2)
 orDecoder = binDecoder (\t1 t2 -> Or t1 t2)
@@ -417,6 +419,7 @@ listSubterms t =
     Plus x y ->  [x, y]
     Minus x y -> [x, y]
     Times x y -> [x, y]
+    Div x y   -> [x, y]
     Mod x y   -> [x, y]
     Eq x y ->    [x, y]
     And x y ->   [x, y]
@@ -484,6 +487,7 @@ renderTermInline result t =
         Plus _ _       -> "+"
         Minus _ _      -> "-"
         Times _ _      -> "*"
+        Div _ _        -> "/"
         Mod _ _        -> "%"
         Eq _ _         -> "=="
         And _ _        -> "&&"
@@ -564,6 +568,7 @@ genRenderTree depth e t =
         Plus x y  -> [gTree x, gTree y]
         Minus x y -> [gTree x, gTree y]
         Times x y -> [gTree x, gTree y]
+        Div x y   -> [gTree x, gTree y]
         Mod x y   -> [gTree x, gTree y]
         Eq x y    -> [gTree x, gTree y]
         And x y   -> [gTree x, gTree y]

--- a/src/Typecheck.elm
+++ b/src/Typecheck.elm
@@ -113,6 +113,7 @@ getTypeArgs env t =
       Plus x y  -> (check x) :: (check y) :: []
       Minus x y -> (check x) :: (check y) :: []
       Times x y -> (check x) :: (check y) :: []
+      Div x y   -> (check x) :: (check y) :: []
       Mod x y   -> (check x) :: (check y) :: []
       Eq x y    -> (check x) :: (check y) :: []
       And x y   -> (check x) :: (check y) :: []

--- a/src/Typecheck.elm
+++ b/src/Typecheck.elm
@@ -113,6 +113,7 @@ getTypeArgs env t =
       Plus x y  -> (check x) :: (check y) :: []
       Minus x y -> (check x) :: (check y) :: []
       Times x y -> (check x) :: (check y) :: []
+      Mod x y   -> (check x) :: (check y) :: []
       Eq x y    -> (check x) :: (check y) :: []
       And x y   -> (check x) :: (check y) :: []
       Or x y    -> (check x) :: (check y) :: []

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -12,10 +12,10 @@ type TokTSCBool = TokEq | TokAnd | TokOr
 
 type Const = CBool Bool | CInt Int
 type Term = CTerm Const | VTerm String | Plus Term Term | Minus Term Term | Times Term Term
-            | Eq Term Term | And Term Term | Or Term Term | Lam String Term | App Term Term
-            | MissingInt | MissingBool | Missing | EmptyTree
+              | Mod Term Term | Eq Term Term | And Term Term | Or Term Term | Lam String Term
+              | App Term Term | MissingInt | MissingBool | Missing | EmptyTree
 
-{- 
+{-
   V(alue)Type is a type that a TreeAssembly term can evaluate to
 -}
 type VType = TBool | TInt | TFun VType VType
@@ -39,6 +39,7 @@ getTypeSignature t =
     Eq x y -> Just (TFun TInt (TFun TInt TBool))
     And x y -> Just (TFun TBool (TFun TBool TBool))
     Or x y -> Just (TFun TBool (TFun TBool TBool))
+    Mod x y -> Just (TFun TInt (TFun TInt TInt))
     Lam x y -> Nothing --Need to work on this.
     App x y -> Nothing --Might have to change this later on
     _ -> Nothing

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -12,8 +12,8 @@ type TokTSCBool = TokEq | TokAnd | TokOr
 
 type Const = CBool Bool | CInt Int
 type Term = CTerm Const | VTerm String | Plus Term Term | Minus Term Term | Times Term Term
-              | Mod Term Term | Eq Term Term | And Term Term | Or Term Term | Lam String Term
-              | App Term Term | MissingInt | MissingBool | Missing | EmptyTree
+              | Div Term Term | Mod Term Term | Eq Term Term | And Term Term | Or Term Term
+              | Lam String Term | App Term Term | MissingInt | MissingBool | Missing | EmptyTree
 
 {-
   V(alue)Type is a type that a TreeAssembly term can evaluate to
@@ -36,10 +36,11 @@ getTypeSignature t =
     Plus x y -> Just (TFun TInt (TFun TInt TInt))
     Minus x y -> Just (TFun TInt (TFun TInt TInt))
     Times x y -> Just (TFun TInt (TFun TInt TInt))
+    Div x y -> Just (TFun TInt (TFun TInt TInt))
+    Mod x y -> Just (TFun TInt (TFun TInt TInt))
     Eq x y -> Just (TFun TInt (TFun TInt TBool))
     And x y -> Just (TFun TBool (TFun TBool TBool))
     Or x y -> Just (TFun TBool (TFun TBool TBool))
-    Mod x y -> Just (TFun TInt (TFun TInt TInt))
     Lam x y -> Nothing --Need to work on this.
     App x y -> Nothing --Might have to change this later on
     _ -> Nothing

--- a/src/parser/lexing.js
+++ b/src/parser/lexing.js
@@ -35,6 +35,7 @@ const Assignment = createToken({ name: "Assignment", pattern: /=/ })
 const Addition = createToken({name: "Addition", pattern: /\+/ })
 const Subtraction = createToken({name: "Subtraction", pattern: /-/ })
 const Multiplication = createToken({name: "Multiplication", pattern: /\*/ })
+const Division = createToken({name: "Division", pattern: /\//})
 const Modulus = createToken({name: "Modulus", pattern: /%/})
 
 const LogicalOR = createToken({name: "LogicalOR", pattern: /\|\|/ })
@@ -63,6 +64,7 @@ const allTokens = [
     Addition,
     Subtraction,
     Multiplication,
+    Division,
     Modulus,
     LogicalOR,
     LogicalAND,

--- a/src/parser/lexing.js
+++ b/src/parser/lexing.js
@@ -35,6 +35,7 @@ const Assignment = createToken({ name: "Assignment", pattern: /=/ })
 const Addition = createToken({name: "Addition", pattern: /\+/ })
 const Subtraction = createToken({name: "Subtraction", pattern: /-/ })
 const Multiplication = createToken({name: "Multiplication", pattern: /\*/ })
+const Modulus = createToken({name: "Modulus", pattern: /%/})
 
 const LogicalOR = createToken({name: "LogicalOR", pattern: /\|\|/ })
 const LogicalAND = createToken({name: "LogicalAND", pattern: /&&/ })
@@ -62,6 +63,7 @@ const allTokens = [
     Addition,
     Subtraction,
     Multiplication,
+    Modulus,
     LogicalOR,
     LogicalAND,
     LParen,

--- a/src/parser/parsing.js
+++ b/src/parser/parsing.js
@@ -20,6 +20,7 @@ const Assignment = tokenVocabulary.Assignment
 const Addition = tokenVocabulary.Addition
 const Subtraction = tokenVocabulary.Subtraction
 const Multiplication = tokenVocabulary.Multiplication
+const Division = tokenVocabulary.Division
 const Modulus = tokenVocabulary.Modulus
 const LogicalOR = tokenVocabulary.LogicalOR
 const LogicalAND = tokenVocabulary.LogicalAND
@@ -132,9 +133,17 @@ class ScriptParser extends Parser {
         })
 
         $.RULE("multExpression", () => {
-            $.SUBRULE($.modExpression)
+            $.SUBRULE($.divExpression)
             $.MANY( () => {
                 $.CONSUME(Multiplication)
+                $.SUBRULE2($.divExpression)
+            })
+        })
+
+        $.RULE("divExpression", () => {
+            $.SUBRULE($.modExpression)
+            $.MANY( () => {
+                $.CONSUME(Division)
                 $.SUBRULE2($.modExpression)
             })
         })

--- a/src/parser/parsing.js
+++ b/src/parser/parsing.js
@@ -20,6 +20,7 @@ const Assignment = tokenVocabulary.Assignment
 const Addition = tokenVocabulary.Addition
 const Subtraction = tokenVocabulary.Subtraction
 const Multiplication = tokenVocabulary.Multiplication
+const Modulus = tokenVocabulary.Modulus
 const LogicalOR = tokenVocabulary.LogicalOR
 const LogicalAND = tokenVocabulary.LogicalAND
 const LParen = tokenVocabulary.LParen
@@ -37,8 +38,8 @@ class ScriptParser extends Parser {
 
         $.RULE("statement", () => {
             $.OR([
-                { ALT: () => { $.SUBRULE($.typeStatement) }}, 
-                { ALT: () => { $.SUBRULE($.assignmentStatement) }}, 
+                { ALT: () => { $.SUBRULE($.typeStatement) }},
+                { ALT: () => { $.SUBRULE($.assignmentStatement) }},
             ])
         })
 
@@ -62,10 +63,10 @@ class ScriptParser extends Parser {
                     $.CONSUME(LParen)
                     $.SUBRULE($.type)
                     $.CONSUME(RParen)
-                }}, 
-                { ALT: () => { $.CONSUME(BasicType) }}, 
+                }},
+                { ALT: () => { $.CONSUME(BasicType) }},
             ])
-            
+
         })
 
         $.RULE("assignmentStatement", () => {
@@ -77,7 +78,7 @@ class ScriptParser extends Parser {
         $.RULE("expression", () => {
             $.SUBRULE($.fnExpression)
         })
-        
+
         $.RULE("fnExpression", () => {
             $.OR([
                 { ALT: () => {
@@ -85,8 +86,8 @@ class ScriptParser extends Parser {
                     $.CONSUME(Identifier)
                     $.CONSUME(Arrow)
                     $.SUBRULE($.eqExpression)
-                }}, 
-                { ALT: () => { $.SUBRULE2($.eqExpression) }}, 
+                }},
+                { ALT: () => { $.SUBRULE2($.eqExpression) }},
             ])
         })
 
@@ -105,6 +106,7 @@ class ScriptParser extends Parser {
                 $.SUBRULE2($.andExpression)
             })
         })
+
         $.RULE("andExpression", () => {
             $.SUBRULE($.subtExpression)
             $.MANY( () => {
@@ -130,9 +132,17 @@ class ScriptParser extends Parser {
         })
 
         $.RULE("multExpression", () => {
-            $.SUBRULE($.appExpression)
+            $.SUBRULE($.modExpression)
             $.MANY( () => {
                 $.CONSUME(Multiplication)
+                $.SUBRULE2($.modExpression)
+            })
+        })
+
+        $.RULE("modExpression", () => {
+            $.SUBRULE($.appExpression)
+            $.MANY( () => {
+                $.CONSUME(Modulus)
                 $.SUBRULE2($.appExpression)
             })
         })

--- a/src/parser/visitor.js
+++ b/src/parser/visitor.js
@@ -187,12 +187,25 @@ class ToAstVisitor extends BaseScriptVisitor {
             return this.visit(ctx.multExpression)
         }
     }
-    
+
     multExpression(ctx) {
+        if(ctx.modExpression.length > 1) {
+            const children = ctx.modExpression.map(node => this.visit(node))
+            return {
+                type: "MULT_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.modExpression)
+        }
+    }
+
+    modExpression(ctx) {
         if(ctx.appExpression.length > 1) {
             const children = ctx.appExpression.map(node => this.visit(node))
             return {
-                type: "MULT_EXPR",
+                type: "MOD_EXPR",
                 children: children,
             }
         }

--- a/src/parser/visitor.js
+++ b/src/parser/visitor.js
@@ -189,10 +189,23 @@ class ToAstVisitor extends BaseScriptVisitor {
     }
 
     multExpression(ctx) {
+        if(ctx.divExpression.length > 1) {
+            const children = ctx.divExpression.map(node => this.visit(node))
+            return {
+                type: "MULT_EXPR",
+                children: children,
+            }
+        }
+        else {
+            return this.visit(ctx.divExpression)
+        }
+    }
+
+    divExpression(ctx) {
         if(ctx.modExpression.length > 1) {
             const children = ctx.modExpression.map(node => this.visit(node))
             return {
-                type: "MULT_EXPR",
+                type: "DIV_EXPR",
                 children: children,
             }
         }

--- a/tests/EvaluateTests.elm
+++ b/tests/EvaluateTests.elm
@@ -47,7 +47,25 @@ suite =
             Plus (CTerm (CInt 5)) (CTerm (CInt 3))
               |> eval env
               |> Expect.equal (Just (VInt 8))
-      
+
+      , test "division" <|
+        \_ ->
+          let
+            env = []
+          in
+            Div (CTerm (CInt 5)) (CTerm (CInt 3))
+              |> eval env
+              |> Expect.equal (Just (VInt 1))
+
+      , test "modulus" <|
+        \_ ->
+          let
+            env = []
+          in
+            Div (CTerm (CInt 22)) (CTerm (CInt 4))
+              |> eval env
+              |> Expect.equal (Just (VInt 2))
+
       , test "or" <|
         \_ ->
           let
@@ -74,7 +92,7 @@ suite =
             VTerm "x"
               |> eval env
               |> Expect.equal (Just (VInt 9))
-              
+
        , test "lambdas evaluate to closures" <|
         \_ ->
           let
@@ -83,7 +101,7 @@ suite =
             Lam "x" (Plus (VTerm "x") (CTerm (CInt 2)))
               |> eval env
               |> Expect.equal (Just (VFun env "x" (Plus (VTerm "x") (CTerm (CInt 2)))))
-              
+
         , test "applications evaluate with environment" <|
         \_ ->
           let

--- a/tests/EvaluateTests.elm
+++ b/tests/EvaluateTests.elm
@@ -62,7 +62,7 @@ suite =
           let
             env = []
           in
-            Div (CTerm (CInt 22)) (CTerm (CInt 4))
+            Mod (CTerm (CInt 22)) (CTerm (CInt 4))
               |> eval env
               |> Expect.equal (Just (VInt 2))
 


### PR DESCRIPTION
I implemented the division and modulus operators.

This is a table of the symbols used by Haskell, Elm, and our language:
  Haskell  |       Elm      |    Arboretum
  `quot ` |       `// `      |          `/`
  `mod`  |  `modBy`  |         `%`

Let me know if you agree/disagree with this convention.